### PR TITLE
Finish Logout Use Case

### DIFF
--- a/src/main/java/use_case/logout/LogoutInputData.java
+++ b/src/main/java/use_case/logout/LogoutInputData.java
@@ -4,10 +4,15 @@ package use_case.logout;
  * The Input Data for the Logout Use Case.
  */
 public class LogoutInputData {
-    private String username;
+    private final String username;
 
     public LogoutInputData(String username) {
-        // TODO: save the current username in an instance variable and add a getter.
+        this.username = username;
+        // : save the current username in an instance variable and add a getter.
+    }
+
+    public String getUsername() {
+        return username;
     }
 
 }

--- a/src/main/java/use_case/logout/LogoutInteractor.java
+++ b/src/main/java/use_case/logout/LogoutInteractor.java
@@ -4,22 +4,31 @@ package use_case.logout;
  * The Logout Interactor.
  */
 public class LogoutInteractor implements LogoutInputBoundary {
-    private LogoutUserDataAccessInterface userDataAccessObject;
-    private LogoutOutputBoundary logoutPresenter;
+    private final LogoutUserDataAccessInterface userDataAccessObject;
+    private final LogoutOutputBoundary logoutPresenter;
 
     public LogoutInteractor(LogoutUserDataAccessInterface userDataAccessInterface,
                             LogoutOutputBoundary logoutOutputBoundary) {
-        // TODO: save the DAO and Presenter in the instance variables.
+        // save the DAO and Presenter in the instance variables.
         // Which parameter is the DAO and which is the presenter?
+
+        this.userDataAccessObject = userDataAccessInterface;
+        this.logoutPresenter = logoutOutputBoundary;
     }
 
     @Override
     public void execute(LogoutInputData logoutInputData) {
-        // TODO: implement the logic of the Logout Use Case (depends on the LogoutInputData.java TODO)
+        // implement the logic of the Logout Use Case (depends on the LogoutInputData.java)
         // * get the username out of the input data,
+        final String currentUsername = logoutInputData.getUsername();
         // * set the username to null in the DAO
+        userDataAccessObject.setCurrentUsername(null);
         // * instantiate the `LogoutOutputData`, which needs to contain the username.
+        final LogoutOutputData logoutOutputData = new LogoutOutputData(currentUsername, false);
+        // I'm assuming that useCaseFailed is false.
         // * tell the presenter to prepare a success view.
+        logoutPresenter.prepareSuccessView(logoutOutputData);
+        // Should we consider the case of the fail in this case? I'm assuming not because it is executing.
     }
 }
 


### PR DESCRIPTION
This PR wraps up the core logic for the logout functionality. In the LogoutInputData class, I fixed the username field to be final and added a getter so the interactor can pull the username out cleanly.

On the interactor side, I wired up the constructor to store the data access object and presenter properly. Then in the execute method, I implemented the full logout flow, which gets the current username from the input data, clears it from the DAO by setting it to null, and then creates a LogoutOutputData object with that username and tells the presenter to render the success view.

IMPORTANT NOTE: I’m assuming logout always succeeds, since there’s no obvious failure case if the current user is already set. Let me know if we want to handle something like that later. I wasn't too sure about this decision.