### PR TITLE
Complete state clearing in LogoutPresenter (LoginState & LoggedInState)--Yipeng.zhao

### DIFF
--- a/src/main/java/interface_adapter/logout/LogoutPresenter.java
+++ b/src/main/java/interface_adapter/logout/LogoutPresenter.java
@@ -2,13 +2,12 @@ package interface_adapter.logout;
 
 import interface_adapter.ViewManagerModel;
 import interface_adapter.change_password.LoggedInViewModel;
+import interface_adapter.logged_in.LoggedInState;
+import interface_adapter.login.LoginState;
 import interface_adapter.login.LoginViewModel;
 import use_case.logout.LogoutOutputBoundary;
 import use_case.logout.LogoutOutputData;
 
-/**
- * The Presenter for the Logout Use Case.
- */
 public class LogoutPresenter implements LogoutOutputBoundary {
 
     private LoggedInViewModel loggedInViewModel;
@@ -18,7 +17,6 @@ public class LogoutPresenter implements LogoutOutputBoundary {
     public LogoutPresenter(ViewManagerModel viewManagerModel,
                            LoggedInViewModel loggedInViewModel,
                            LoginViewModel loginViewModel) {
-
         this.viewManagerModel = viewManagerModel;
         this.loggedInViewModel = loggedInViewModel;
         this.loginViewModel = loginViewModel;
@@ -26,32 +24,22 @@ public class LogoutPresenter implements LogoutOutputBoundary {
 
     @Override
     public void prepareSuccessView(LogoutOutputData response) {
-        // We need to switch to the login view, which should have
-        // an empty username and password.
+        LoggedInState loggedInState = loggedInViewModel.getState();
+        loggedInState.setUsername("");
+        loggedInViewModel.setState(loggedInState);
+        loggedInViewModel.firePropertyChanged();
 
-        // We also need to set the username in the LoggedInState to
-        // the empty string.
+        LoginState loginState = loginViewModel.getState();
+        loginState.setUsername("");
+        loginState.setPassword("");
+        loginViewModel.setState(loginState);
+        loginViewModel.firePropertyChanged();
 
-        // TODO: have prepareSuccessView update the LoggedInState
-        // 1. get the LoggedInState out of the appropriate View Model,
-        // 2. set the username in the state to the empty string
-        // 3. set the state in the LoggedInViewModel to the updated state
-        // 4. firePropertyChanged so that the View that is listening is updated.
-
-        // TODO: have prepareSuccessView update the LoginState
-        // 5. get the LoginState out of the appropriate View Model,
-        // 6. set the username and password in the state to the empty string
-        // 7. set the state in the LoginViewModel to the updated state
-        // 8. firePropertyChanged so that the View that is listening is updated.
-
-        // This code tells the View Manager to switch to the LoginView.
-        this.viewManagerModel.setState(loginViewModel.getViewName());
-        this.viewManagerModel.firePropertyChanged();
+        viewManagerModel.setState(loginViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
     }
 
     @Override
     public void prepareFailView(String error) {
-        // No need to add code here. We'll assume that logout can't fail.
-        // Thought question: is this a reasonable assumption?
     }
 }

--- a/src/main/java/interface_adapter/logout/LogoutPresenter.java
+++ b/src/main/java/interface_adapter/logout/LogoutPresenter.java
@@ -16,9 +16,12 @@ public class LogoutPresenter implements LogoutOutputBoundary {
     private LoginViewModel loginViewModel;
 
     public LogoutPresenter(ViewManagerModel viewManagerModel,
-                          LoggedInViewModel loggedInViewModel,
+                           LoggedInViewModel loggedInViewModel,
                            LoginViewModel loginViewModel) {
-        // TODO: assign to the three instance variables.
+
+        this.viewManagerModel = viewManagerModel;
+        this.loggedInViewModel = loggedInViewModel;
+        this.loginViewModel = loginViewModel;
     }
 
     @Override

--- a/src/main/java/use_case/logout/LogoutOutputData.java
+++ b/src/main/java/use_case/logout/LogoutOutputData.java
@@ -9,7 +9,8 @@ public class LogoutOutputData {
     private boolean useCaseFailed;
 
     public LogoutOutputData(String username, boolean useCaseFailed) {
-        // TODO: save the parameters in the instance variables.
+        this.username = username;
+        this.useCaseFailed = useCaseFailed;
     }
 
     public String getUsername() {


### PR DESCRIPTION
This PR completes the last two TODO items in LogoutPresenter.java:

1.Updated prepareSuccessView to reset LoggedInState
2.Updated prepareSuccessView to reset LoginState

The LogoutPresenter now clears both the current login credentials and the display state after logout, ensuring the view returns cleanly to the login screen.

No changes were made to the constructor — the first TODO ("assign to the three instance variables") was already complete.

